### PR TITLE
Add ips to the benchmark information.

### DIFF
--- a/ppgan/utils/timer.py
+++ b/ppgan/utils/timer.py
@@ -22,12 +22,20 @@ class TimeAverager(object):
     def reset(self):
         self._cnt = 0
         self._total_time = 0
+        self._total_samples = 0
 
-    def record(self, usetime):
+    def record(self, usetime, num_samples=None):
         self._cnt += 1
         self._total_time += usetime
+        if num_samples:
+            self._total_samples += num_samples
 
     def get_average(self):
         if self._cnt == 0:
             return 0
-        return self._total_time / self._cnt
+        return self._total_time / float(self._cnt)
+
+    def get_ips_average(self):
+        if not self._total_samples or self._cnt == 0:
+            return 0
+        return float(self._total_samples) / self._total_time


### PR DESCRIPTION
调整benchmark log信息，并增加ips输出，具体如下：

- CycleGAN
```
[10/23 07:05:06] ppgan.engine.trainer INFO: Epoch: 1, iters: 0 lr: 0.000200 G_idt_A_loss: 2.939 G_idt_B_loss: 2.440 G_A_adv_loss: 1.451 G_B_adv_loss: 1.323 G_A_cycle_loss: 5.020 G_B_cycle_loss: 6.173 D_A_loss: 1.595 D_B_loss: 1.887 batch_cost: 1.75327 sec reader_cost: 0.94611 sec ips: 0.57036 images/s
[10/23 07:05:35] ppgan.engine.trainer INFO: Epoch: 1, iters: 100 lr: 0.000200 G_idt_A_loss: 0.476 G_idt_B_loss: 0.671 G_A_adv_loss: 0.535 G_B_adv_loss: 0.266 G_A_cycle_loss: 1.384 G_B_cycle_loss: 1.018 D_A_loss: 0.146 D_B_loss: 0.317 batch_cost: 0.28896 sec reader_cost: 0.00134 sec ips: 3.46075 images/s
[10/23 07:06:02] ppgan.engine.trainer INFO: Epoch: 1, iters: 200 lr: 0.000200 G_idt_A_loss: 0.641 G_idt_B_loss: 0.556 G_A_adv_loss: 0.632 G_B_adv_loss: 0.511 G_A_cycle_loss: 1.351 G_B_cycle_loss: 1.423 D_A_loss: 0.172 D_B_loss: 0.142 batch_cost: 0.27143 sec reader_cost: 0.00153 sec ips: 3.68421 images/s
[10/23 07:06:28] ppgan.engine.trainer INFO: Epoch: 1, iters: 300 lr: 0.000200 G_idt_A_loss: 0.892 G_idt_B_loss: 0.899 G_A_adv_loss: 0.390 G_B_adv_loss: 0.334 G_A_cycle_loss: 1.984 G_B_cycle_loss: 3.522 D_A_loss: 0.192 D_B_loss: 0.233 batch_cost: 0.25822 sec reader_cost: 0.00141 sec ips: 3.87263 images/s
```

- Pix2pix
```
[10/23 07:50:54] ppgan.engine.trainer INFO: Epoch: 1, iters: 0 lr: 0.000200 D_fake_loss: 1.180 D_real_loss: 0.540 G_adv_loss: 1.412 G_L1_loss: 54.139 batch_cost: 1.43328 sec reader_cost: 0.97620 sec ips: 0.69770 images/s
[10/23 07:50:58] ppgan.engine.trainer INFO: Epoch: 1, iters: 100 lr: 0.000200 D_fake_loss: 0.113 D_real_loss: 0.226 G_adv_loss: 2.719 G_L1_loss: 27.002 batch_cost: 0.03392 sec reader_cost: 0.00074 sec ips: 29.47691 images/s
[10/23 07:51:01] ppgan.engine.trainer INFO: Epoch: 1, iters: 200 lr: 0.000200 D_fake_loss: 1.535 D_real_loss: 0.149 G_adv_loss: 1.231 G_L1_loss: 23.685 batch_cost: 0.03440 sec reader_cost: 0.00082 sec ips: 29.06589 images/s
[10/23 07:51:05] ppgan.engine.trainer INFO: Epoch: 1, iters: 300 lr: 0.000200 D_fake_loss: 0.588 D_real_loss: 0.609 G_adv_loss: 1.210 G_L1_loss: 14.671 batch_cost: 0.03655 sec reader_cost: 0.00085 sec ips: 27.36220 images/s
```