### PR TITLE
modify batch cost time statistics

### DIFF
--- a/ppgan/engine/trainer.py
+++ b/ppgan/engine/trainer.py
@@ -160,6 +160,9 @@ class Trainer:
             batch_cost_averager.record(time.time() - step_start_time,
                                        num_samples=self.cfg.get(
                                            'batch_size', 1))
+
+            step_start_time = time.time()
+
             if self.current_iter % self.log_interval == 0:
                 self.data_time = reader_cost_averager.get_average()
                 self.step_time = batch_cost_averager.get_average()
@@ -171,8 +174,6 @@ class Trainer:
 
             if self.current_iter % self.visual_interval == 0:
                 self.visual('visual_train')
-
-            step_start_time = time.time()
 
             self.model.lr_scheduler.step()
 


### PR DESCRIPTION
gan的print_log中有print(loss)的使用。
loss为tensor，print(loss)=cudasync+as_numpy()+to_string()。是非常耗时的逻辑。
因此，将step_start_time前移，将print_log算入batchcost的统计。