### PR TITLE
fix animeganv2_pretrain.yaml

### DIFF
--- a/configs/animeganv2_pretrain.yaml
+++ b/configs/animeganv2_pretrain.yaml
@@ -83,4 +83,4 @@ log_config:
   visiual_interval: 100
 
 snapshot_config:
-  interval: 5
+  interval: 2


### PR DESCRIPTION
animeganv2_pretrain.yaml中snapshot_config-interval设置过大，超出epochs的范围，导致模型训练结果无法保存