### PR TITLE
[fix bencnmark ]add bencnmark model epochs

### DIFF
--- a/test_tipc/configs/FOMM/train_infer_python.txt
+++ b/test_tipc/configs/FOMM/train_infer_python.txt
@@ -52,7 +52,7 @@ null:null
 ===========================train_benchmark_params==========================
 batch_size:16
 fp_items:fp32
-epoch:5
+epoch:15
 --profiler_options:batch_range=[10,20];state=GPU;tracer_option=Default;profile_path=model.profile
 flags:null
 ===========================infer_benchmark_params==========================


### PR DESCRIPTION
为降低benchmark模型的性能波动，适当增加部分模型的epoch数产出更多有效log