### PR TITLE
fix branchmark

### DIFF
--- a/test_tipc/configs/Pix2pix/train_infer_python.txt
+++ b/test_tipc/configs/Pix2pix/train_infer_python.txt
@@ -13,22 +13,22 @@ train_infer_img_dir:./data/facades/test
 null:null
 ##
 trainer:norm_train
-norm_train:tools/main.py -c configs/pix2pix_facades.yaml --seed 123 -o dataset.train.num_workers=0 log_config.interval=1
+norm_train:tools/main.py -c configs/pix2pix_facades.yaml --seed 123 -o log_config.interval=1
 pact_train:null
 fpgm_train:null
 distill_train:null
 null:null
 null:null
 ##
-===========================eval_params=========================== 
+===========================eval_params===========================
 eval:null
 null:null
 ##
 ===========================infer_params===========================
 --output_dir:./output/
 load:null
-norm_export:tools/export_model.py -c configs/pix2pix_facades.yaml --inputs_size="-1,3,-1,-1"  --model_name inference --load 
-quant_export:null 
+norm_export:tools/export_model.py -c configs/pix2pix_facades.yaml --inputs_size="-1,3,-1,-1"  --model_name inference --load
+quant_export:null
 fpgm_export:null
 distill_export:null
 export1:null

--- a/test_tipc/configs/StyleGANv2/train_infer_python.txt
+++ b/test_tipc/configs/StyleGANv2/train_infer_python.txt
@@ -13,7 +13,7 @@ train_infer_img_dir:null
 null:null
 ##
 trainer:norm_train
-norm_train:tools/main.py -c configs/stylegan_v2_256_ffhq.yaml --seed 123 -o dataset.train.num_workers=0 log_config.interval=1 snapshot_config.interval=10
+norm_train:tools/main.py -c configs/stylegan_v2_256_ffhq.yaml --seed 123 -o log_config.interval=1 snapshot_config.interval=10
 pact_train:null
 fpgm_train:null
 distill_train:null

--- a/test_tipc/configs/basicvsr/train_infer_python.txt
+++ b/test_tipc/configs/basicvsr/train_infer_python.txt
@@ -13,22 +13,22 @@ train_infer_img_dir:./data/basicvsr_reds/test
 null:null
 ##
 trainer:norm_train
-norm_train:tools/main.py -c configs/basicvsr_reds.yaml --seed 123 -o dataset.train.num_workers=0 log_config.interval=1 snapshot_config.interval=5 
+norm_train:tools/main.py -c configs/basicvsr_reds.yaml --seed 123 -o log_config.interval=1 snapshot_config.interval=5
 pact_train:null
 fpgm_train:null
 distill_train:null
 null:null
 null:null
 ##
-===========================eval_params=========================== 
+===========================eval_params===========================
 eval:null
 null:null
 ##
 ===========================infer_params===========================
 --output_dir:./output/
 load:null
-norm_export:tools/export_model.py -c configs/basicvsr_reds.yaml  --inputs_size="1,6,3,180,320" --model_name inference --load 
-quant_export:null 
+norm_export:tools/export_model.py -c configs/basicvsr_reds.yaml  --inputs_size="1,6,3,180,320" --model_name inference --load
+quant_export:null
 fpgm_export:null
 distill_export:null
 export1:null

--- a/test_tipc/configs/edvr/train_infer_python.txt
+++ b/test_tipc/configs/edvr/train_infer_python.txt
@@ -13,14 +13,14 @@ train_infer_img_dir:./data/basicvsr_reds/test
 null:null
 ##
 trainer:norm_train
-norm_train:tools/main.py -c configs/edvr_m_wo_tsa.yaml --seed 123 -o dataset.train.num_workers=0 log_config.interval=5
+norm_train:tools/main.py -c configs/edvr_m_wo_tsa.yaml --seed 123 -o log_config.interval=5
 pact_train:null
 fpgm_train:null
 distill_train:null
 null:null
 null:null
 ##
-===========================eval_params=========================== 
+===========================eval_params===========================
 eval:null
 null:null
 ##

--- a/test_tipc/configs/esrgan/train_infer_python.txt
+++ b/test_tipc/configs/esrgan/train_infer_python.txt
@@ -13,14 +13,14 @@ train_infer_img_dir:null
 null:null
 ##
 trainer:norm_train
-norm_train:tools/main.py -c configs/esrgan_psnr_x4_div2k.yaml --seed 123 -o dataset.train.num_workers=0 log_config.interval=5 
+norm_train:tools/main.py -c configs/esrgan_psnr_x4_div2k.yaml --seed 123 -o log_config.interval=5
 pact_train:null
 fpgm_train:null
 distill_train:null
 null:null
 null:null
 ##
-===========================eval_params=========================== 
+===========================eval_params===========================
 eval:null
 null:null
 ##


### PR DESCRIPTION
Fix the problem that the performance of the new dynamic graph of the GAN model decreases more than the old dynamic graph when dataset.train.num_workers=0.
Corresponding card: https://console.cloud.baidu-int.com/devops/icafe/issue/DLTP-53422/show