### PR TITLE
[chore] Free librosa version

### DIFF
--- a/ppgan/utils/audio.py
+++ b/ppgan/utils/audio.py
@@ -22,11 +22,6 @@ def save_wav(wav, path, sr):
     wavfile.write(path, sr, wav.astype(np.int16))
 
 
-def save_wavenet_wav(wav, path, sr):
-    librosa = try_import('librosa')
-    librosa.output.write_wav(path, wav, sr=sr)
-
-
 def preemphasis(wav, k, preemphasize=True):
     if preemphasize:
         return signal.lfilter([1, -k], [1], wav)

--- a/ppgan/utils/audio.py
+++ b/ppgan/utils/audio.py
@@ -130,8 +130,8 @@ def _linear_to_mel(spectogram):
 def _build_mel_basis():
     assert audio_config.fmax <= audio_config.sample_rate // 2
     librosa = try_import('librosa')
-    return librosa.filters.mel(audio_config.sample_rate,
-                               audio_config.n_fft,
+    return librosa.filters.mel(sr=audio_config.sample_rate,
+                               n_fft=audio_config.n_fft,
                                n_mels=audio_config.num_mels,
                                fmin=audio_config.fmin,
                                fmax=audio_config.fmax)

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ scipy>=1.1.0
 opencv-python
 imageio==2.9.0
 imageio-ffmpeg
-librosa==0.8.1
+librosa>=0.8.1
 numba==0.53.1
 easydict
 munch


### PR DESCRIPTION
(zh version after en | 英文后面是中文)

## Why? | 为什么？

Locking librosa strictly to v0.8.1 makes PaddleGAN more difficult to be used with other packages.

---

把 librosa 版本严格锁在 v0.8.1 导致 PaddleGAN 更难和其它包一起使用。

## Is it safe? | 这安全吗？

We only use librosa to read/write wav! [Search librosa in the repo.](https://github.com/PaddlePaddle/PaddleGAN/search?q=librosa)

(You can check the [change log](http://librosa.org/doc/latest/changelog.html) if you want)

---

~~我们用 librosa 只是为了读写 wav！~~[在仓库中搜索 librosa。](https://github.com/PaddlePaddle/PaddleGAN/search?q=librosa)

（也可再检查一下[更新日志](http://librosa.org/doc/latest/changelog.html)）

## History of the librosa version | librosa 版本的历史

1. Add librosa v0.7.0: [add requirement for wav2lip (#147) @a8ba73b](https://github.com/PaddlePaddle/PaddleGAN/commit/a8ba73ba2fec65e07a5a7dcce4de0a9034552982)
2. Free librosa version: [fix numba install in py39 (#427) @5a639c0](https://github.com/PaddlePaddle/PaddleGAN/commit/5a639c063681c5e0659d37bfe3bdccbeaa840d67)
3. Lock librosa to v0.8.1: [update librosa version (#504) @0235853](https://github.com/PaddlePaddle/PaddleGAN/commit/02358537e7fe50b63d424c41987649c690e32026)

---

1. 添加 librosa v0.7.0: [添加 wav2lip 的依赖 (#147) @a8ba73b](https://github.com/PaddlePaddle/PaddleGAN/commit/a8ba73ba2fec65e07a5a7dcce4de0a9034552982)
2. 放松 librosa 版本: [fix numba install in py39 (#427) @5a639c0](https://github.com/PaddlePaddle/PaddleGAN/commit/5a639c063681c5e0659d37bfe3bdccbeaa840d67)
3. 锁定 librosa 到 v0.8.1: [更新 librosa 版本 (#504) @0235853](https://github.com/PaddlePaddle/PaddleGAN/commit/02358537e7fe50b63d424c41987649c690e32026)