### PR TITLE
[TIPC] Fix benchmark bug

### DIFF
--- a/ppgan/models/msvsr_model.py
+++ b/ppgan/models/msvsr_model.py
@@ -132,7 +132,7 @@ class MultiStageVSRModel(BaseSRModel):
             self.loss = sum(_value for _key, _value in self.losses.items()
                             if 'loss_pix' in _key)
         scaled_loss = scaler.scale(self.loss)
-        self.losses['loss'] = scaled_loss
+        self.losses['loss'] = self.loss
 
         scaled_loss.backward()
         scaler.minimize(optims['optim'], scaled_loss)

--- a/test_tipc/benchmark_train.sh
+++ b/test_tipc/benchmark_train.sh
@@ -100,11 +100,10 @@ for _flag in ${flags_list[*]}; do
 done
 
 # set log_name
-BENCHMARK_ROOT=./ # self-test only
 repo_name=$(get_repo_name )
-SAVE_LOG=${BENCHMARK_LOG_DIR:-$(pwd)}   # */benchmark_log
-mkdir -p "${SAVE_LOG}/benchmark_log/"
-status_log="${SAVE_LOG}/benchmark_log/results.log"
+SAVE_LOG="${BENCHMARK_LOG_DIR:-$(pwd)}/benchmark_log" # */benchmark_log
+mkdir -p "${SAVE_LOG}"
+status_log="${SAVE_LOG}/results.log"
 
 # The number of lines in which train params can be replaced.
 line_python=3

--- a/test_tipc/prepare.sh
+++ b/test_tipc/prepare.sh
@@ -28,9 +28,11 @@ function func_parser_value(){
 IFS=$'\n'
 # The training params
 model_name=$(func_parser_value "${lines[1]}")
-
 trainer_list=$(func_parser_value "${lines[14]}")
 
+if [ ${MODE} = "benchmark_train" ];then
+    MODE="lite_train_lite_infer"
+fi
 
 if [ ${MODE} = "lite_train_lite_infer" ];then
 
@@ -164,12 +166,6 @@ elif [ ${MODE} = "whole_infer" ];then
         cd ./inference/ && unzip -q singan.zip && cd ../
         mkdir -p ./data/singan
         mv ./data/SinGAN-official_images/Images/stone.png ./data/singan
-    fi
-elif [ ${MODE} = "benchmark_train" ];then
-    if [ ${model_name} == "msvsr" ]; then
-        rm -rf ./data/reds*
-        wget -nc -P ./data/ https://paddlegan.bj.bcebos.com/datasets/reds_lite.tar --no-check-certificate
-        cd ./data/ && tar xf reds_lite.tar && cd ../
     fi
 elif [ ${MODE} = "cpp_infer" ]; then
     if [ ${model_name} == "msvsr" ]; then

--- a/test_tipc/test_train_inference_python.sh
+++ b/test_tipc/test_train_inference_python.sh
@@ -210,8 +210,10 @@ else
         for autocast in ${autocast_list[*]}; do
             if [ ${autocast} = "fp16" ]; then
                 set_amp_config="--amp"
+                set_amp_level="--amp_level=O2"
             else
                 set_amp_config=" "
+                set_amp_level=" "
             fi
             for trainer in ${trainer_list[*]}; do
                 flag_quant=False
@@ -239,11 +241,11 @@ else
                 fi
                 set_save_model=$(func_set_params "${save_model_key}" "${save_log}")
                 if [ ${#gpu} -le 2 ];then  # train with cpu or single gpu
-                    cmd="${python} ${run_train} ${set_use_gpu}  ${set_save_model} ${set_train_params1} ${set_epoch} ${set_pretrain} ${set_batchsize} ${set_amp_config}"
+                    cmd="${python} ${run_train} ${set_use_gpu}  ${set_save_model} ${set_train_params1} ${set_epoch} ${set_pretrain} ${set_batchsize} ${set_amp_config} ${set_amp_level}"
                 elif [ ${#ips} -le 26 ];then  # train with multi-gpu
-                    cmd="${python} -m paddle.distributed.launch --gpus=${gpu} ${run_train} ${set_use_gpu} ${set_save_model} ${set_train_params1} ${set_epoch} ${set_pretrain} ${set_batchsize} ${set_amp_config}"
+                    cmd="${python} -m paddle.distributed.launch --gpus=${gpu} ${run_train} ${set_use_gpu} ${set_save_model} ${set_train_params1} ${set_epoch} ${set_pretrain} ${set_batchsize} ${set_amp_config} ${set_amp_level}"
                 else     # train with multi-machine
-                    cmd="${python} -m paddle.distributed.launch --ips=${ips} --gpus=${gpu} ${run_train} ${set_use_gpu} ${set_save_model} ${set_train_params1} ${set_pretrain} ${set_epoch} ${set_batchsize} ${set_amp_config}"
+                    cmd="${python} -m paddle.distributed.launch --ips=${ips} --gpus=${gpu} ${run_train} ${set_use_gpu} ${set_save_model} ${set_train_params1} ${set_pretrain} ${set_epoch} ${set_batchsize} ${set_amp_config} ${set_amp_level}"
                 fi
                 # run train
                 eval "unset CUDA_VISIBLE_DEVICES"


### PR DESCRIPTION
1. 修复`prepare.sh`，其它模型的benchmark_train不受影响。
2. 屏蔽掉`BENCHMARK_ROOT`变量，用于日志分析。
3. fp16改成O2训练。