### PR TITLE
[TIPC] Add script for npu and xpu, test=develop

### DIFF
--- a/ppgan/utils/setup.py
+++ b/ppgan/utils/setup.py
@@ -43,6 +43,8 @@ def setup(args, cfg):
 
     if paddle.is_compiled_with_cuda():
         paddle.set_device('gpu')
+    elif paddle.is_compiled_with_npu():
+        paddle.set_device('npu')
     else:
         paddle.set_device('cpu')
 

--- a/ppgan/utils/setup.py
+++ b/ppgan/utils/setup.py
@@ -45,6 +45,8 @@ def setup(args, cfg):
         paddle.set_device('gpu')
     elif paddle.is_compiled_with_npu():
         paddle.set_device('npu')
+    elif paddle.is_compiled_with_xpu():
+        paddle.set_device('xpu')
     else:
         paddle.set_device('cpu')
 

--- a/test_tipc/test_train_inference_python_npu.sh
+++ b/test_tipc/test_train_inference_python_npu.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+source test_tipc/common_func.sh
+
+function readlinkf() {
+    perl -MCwd -e 'print Cwd::abs_path shift' "$1";
+}
+
+function func_parser_config() {
+    strs=$1
+    IFS=" "
+    array=(${strs})
+    tmp=${array[2]}
+    echo ${tmp}
+}
+
+BASEDIR=$(dirname "$0")
+REPO_ROOT_PATH=$(readlinkf ${BASEDIR}/../)
+
+FILENAME=$1
+
+# change gpu to npu in tipc txt configs
+sed -i "s/state=GPU/state=NPU/g" $FILENAME
+sed -i "s/--device:gpu/--device:npu/g" $FILENAME
+sed -i "s/--benchmark:True/--benchmark:False/g" $FILENAME
+dataline=`cat $FILENAME`
+
+# change gpu to npu in execution script
+sed -i 's/\"gpu\"/\"npu\"/g' test_tipc/test_train_inference_python.sh
+sed -i 's/--gpus/--npus/g' test_tipc/test_train_inference_python.sh
+
+# parser params
+IFS=$'\n'
+lines=(${dataline})
+
+# pass parameters to test_train_inference_python.sh
+cmd="bash test_tipc/test_train_inference_python.sh ${FILENAME} $2"
+echo $cmd
+eval $cmd

--- a/test_tipc/test_train_inference_python_xpu.sh
+++ b/test_tipc/test_train_inference_python_xpu.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+source test_tipc/common_func.sh
+
+function readlinkf() {
+    perl -MCwd -e 'print Cwd::abs_path shift' "$1";
+}
+
+function func_parser_config() {
+    strs=$1
+    IFS=" "
+    array=(${strs})
+    tmp=${array[2]}
+    echo ${tmp}
+}
+
+BASEDIR=$(dirname "$0")
+REPO_ROOT_PATH=$(readlinkf ${BASEDIR}/../)
+
+FILENAME=$1
+
+# change gpu to npu in tipc txt configs
+sed -i "s/state=GPU/state=XPU/g" $FILENAME
+sed -i "s/--device:gpu/--device:xpu/g" $FILENAME
+sed -i "s/--benchmark:True/--benchmark:False/g" $FILENAME
+dataline=`cat $FILENAME`
+
+# change gpu to npu in execution script
+sed -i 's/\"gpu\"/\"xpu\"/g' test_tipc/test_train_inference_python.sh
+sed -i 's/--gpus/--xpus/g' test_tipc/test_train_inference_python.sh
+
+# parser params
+IFS=$'\n'
+lines=(${dataline})
+
+# pass parameters to test_train_inference_python.sh
+cmd="bash test_tipc/test_train_inference_python.sh ${FILENAME} $2"
+echo $cmd
+eval $cmd

--- a/tools/fom_infer.py
+++ b/tools/fom_infer.py
@@ -107,6 +107,12 @@ def main():
     if args.device == "gpu":
         kp_detector_config.enable_use_gpu(100, 0)
         generator_config.enable_use_gpu(100, 0)
+    elif args.device == "xpu":
+        kp_detector_config.enable_xpu(100)
+        generator_config.enable_xpu(100)
+    elif args.device == "npu":
+        kp_detector_config.enable_npu()
+        generator_config.enable_npu()
     else:
         kp_detector_config.set_mkldnn_cache_capacity(10)
         kp_detector_config.enable_mkldnn()

--- a/tools/fom_infer.py
+++ b/tools/fom_infer.py
@@ -108,8 +108,8 @@ def main():
         kp_detector_config.enable_use_gpu(100, 0)
         generator_config.enable_use_gpu(100, 0)
     elif args.device == "xpu":
-        kp_detector_config.enable_xpu(100)
-        generator_config.enable_xpu(100)
+        kp_detector_config.enable_xpu()
+        generator_config.enable_xpu()
     elif args.device == "npu":
         kp_detector_config.enable_npu()
         generator_config.enable_npu()

--- a/tools/inference.py
+++ b/tools/inference.py
@@ -41,7 +41,7 @@ def parse_args():
         "--device",
         default="gpu",
         type=str,
-        choices=["cpu", "gpu", "xpu"],
+        choices=["cpu", "gpu", "xpu", "npu"],
         help="The device to select to train the model, is must be cpu/gpu/xpu.")
     parser.add_argument('-c',
                         '--config-file',
@@ -115,6 +115,8 @@ def create_predictor(model_path,
         config.enable_use_gpu(100, 0)
     elif device == "cpu":
         config.disable_gpu()
+    elif device == "npu":
+        config.enable_npu()
     elif device == "xpu":
         config.enable_xpu(100)
     else:

--- a/tools/inference.py
+++ b/tools/inference.py
@@ -118,7 +118,7 @@ def create_predictor(model_path,
     elif device == "npu":
         config.enable_npu()
     elif device == "xpu":
-        config.enable_xpu(100)
+        config.enable_xpu()
     else:
         config.disable_gpu()
 


### PR DESCRIPTION
为昇腾和昆仑设备添加 TIPC 脚本:

```
# 准备小数据集
bash test_tipc/prepare.sh test_tipc/configs/CycleGAN/train_infer_python.txt 'lite_train_lite_infer'
```

```
# NPU上运行单测模型，注意这里的脚本带 _npu.sh 后缀
bash test_tipc/test_train_inference_python_npu.sh \
     test_tipc/configs/CycleGAN/train_infer_python.txt  'lite_train_lite_infer'
```

```
# XPU上运行单测模型，注意这里的脚本带 _xpu.sh 后缀
bash test_tipc/test_train_inference_python_xpu.sh \
     test_tipc/configs/CycleGAN/train_infer_python.txt  'lite_train_lite_infer'
```