### PR TITLE
fix tensor range for invdn

### DIFF
--- a/configs/invdn_denoising.yaml
+++ b/configs/invdn_denoising.yaml
@@ -1,5 +1,8 @@
 total_iters: 150000
 output_dir: output_dir
+# tensor range for function tensor2img
+min_max:
+  (0., 1.)
 
 model:
   name: InvDNModel


### PR DESCRIPTION
数据范围默认为（-1，1），会导致测试图保存不正确。在yaml配置里修改为了正确的（0，1）