### PR TITLE
[TIPC] Support amp training for esrgan model

### DIFF
--- a/ppgan/models/edvr_model.py
+++ b/ppgan/models/edvr_model.py
@@ -76,7 +76,7 @@ class EDVRModel(BaseSRModel):
         self.current_iter += 1
 
     # amp train with brute force implementation
-    def train_iter_amp(self, optims=None, scaler=None, amp_level='O1'):
+    def train_iter_amp(self, optims=None, scalers=None, amp_level='O1'):
         optims['optim'].clear_grad()
         if self.tsa_iter:
             if self.current_iter == 1:
@@ -97,9 +97,9 @@ class EDVRModel(BaseSRModel):
             loss_pixel = self.pixel_criterion(self.output, self.gt)
             self.losses['loss_pixel'] = loss_pixel
 
-        scaled_loss = scaler.scale(loss_pixel)
+        scaled_loss = scalers[0].scale(loss_pixel)
         scaled_loss.backward()
-        scaler.minimize(optims['optim'], scaled_loss)
+        scalers[0].minimize(optims['optim'], scaled_loss)
 
         self.current_iter += 1
 

--- a/ppgan/models/msvsr_model.py
+++ b/ppgan/models/msvsr_model.py
@@ -98,7 +98,7 @@ class MultiStageVSRModel(BaseSRModel):
         self.current_iter += 1
 
     # amp train with brute force implementation
-    def train_iter_amp(self, optims=None, scaler=None, amp_level='O1'):
+    def train_iter_amp(self, optims=None, scalers=None, amp_level='O1'):
         optims['optim'].clear_grad()
         if self.fix_iter:
             if self.current_iter == 1:
@@ -133,9 +133,9 @@ class MultiStageVSRModel(BaseSRModel):
                             if 'loss_pix' in _key)
             self.losses['loss'] = self.loss
 
-        scaled_loss = scaler.scale(self.loss)
+        scaled_loss = scalers[0].scale(self.loss)
         scaled_loss.backward()
-        scaler.minimize(optims['optim'], scaled_loss)
+        scalers[0].minimize(optims['optim'], scaled_loss)
 
         self.current_iter += 1
 

--- a/test_tipc/configs/edvr/train_infer_python.txt
+++ b/test_tipc/configs/edvr/train_infer_python.txt
@@ -51,7 +51,7 @@ null:null
 null:null
 ===========================train_benchmark_params==========================
 batch_size:64
-fp_items:fp32
+fp_items:fp32|fp16
 total_iters:100
 --profiler_options:batch_range=[10,20];state=GPU;tracer_option=Default;profile_path=model.profile
 flags:FLAGS_cudnn_exhaustive_search=1

--- a/test_tipc/configs/esrgan/train_infer_python.txt
+++ b/test_tipc/configs/esrgan/train_infer_python.txt
@@ -51,7 +51,7 @@ null:null
 null:null
 ===========================train_benchmark_params==========================
 batch_size:32|64
-fp_items:fp32
+fp_items:fp32|fp16
 total_iters:500
 --profiler_options:batch_range=[10,20];state=GPU;tracer_option=Default;profile_path=model.profile
 flags:FLAGS_cudnn_exhaustive_search=1

--- a/test_tipc/configs/msvsr/train_infer_python.txt
+++ b/test_tipc/configs/msvsr/train_infer_python.txt
@@ -51,7 +51,7 @@ null:null
 null:null
 ===========================train_benchmark_params==========================
 batch_size:2|4
-fp_items:fp32
+fp_items:fp32|fp16
 total_iters:60
 --profiler_options:batch_range=[10,20];state=GPU;tracer_option=Default;profile_path=model.profile
 flags:FLAGS_cudnn_exhaustive_search=1

--- a/test_tipc/prepare.sh
+++ b/test_tipc/prepare.sh
@@ -197,5 +197,6 @@ elif [ ${MODE} = "cpp_infer" ]; then
         rm -rf ./inference/msvsr*
         wget -nc  -P ./inference https://paddlegan.bj.bcebos.com/static_model/msvsr.tar --no-check-certificate
         cd ./inference && tar xf msvsr.tar && cd ../
+        wget -nc -P ./data https://paddlegan.bj.bcebos.com/datasets/low_res.mp4 --no-check-certificate
     fi
 fi


### PR DESCRIPTION
1. Add `train_iter_amp` in `ESRGAN` and `BaseSRModel` to support amp training. Since there are multi-loss, multi-optimizers and multi-models in esrgan,  I initialize a GradScaler list according to the number of optimizers.