### PR TITLE
update numba version to be compatible with python3.10

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ opencv-python
 imageio==2.9.0
 imageio-ffmpeg
 librosa==0.8.1
-numba==0.53.1
+numba>=0.53.1
 easydict
 munch
 natsort


### PR DESCRIPTION
thank you for great project!
I have issue with installing ppgan package with python3.10, because there is no such version for numba package on pypi.
Could you please relax it to make it compatibe with new python versions?