### PR TITLE
Fix pylint warning `raise-missing-from`

### DIFF
--- a/ppgan/apps/wav2lip_predictor.py
+++ b/ppgan/apps/wav2lip_predictor.py
@@ -73,11 +73,9 @@ class Wav2LipPredictor(BasePredictor):
                     predictions.extend(
                         detector.get_detections_for_batch(
                             np.array(images[i:i + batch_size])))
-            except RuntimeError:
+            except RuntimeError as exc:
                 if batch_size == 1:
-                    raise RuntimeError(
-                        'Image too big to run face detection on GPU. Please use the --resize_factor argument'
-                    )
+                    raise RuntimeError('Image too big to run face detection on GPU. Please use the --resize_factor argument') from exc
                 batch_size //= 2
                 print('Recovering from OOM error; New batch size: {}'.format(
                     batch_size))

--- a/ppgan/datasets/preprocess/builder.py
+++ b/ppgan/datasets/preprocess/builder.py
@@ -47,7 +47,7 @@ class Compose(object):
                 stack_info = traceback.format_exc()
                 print("fail to perform fuction [{}] with error: "
                       "{} and stack:\n{}".format(func, e, str(stack_info)))
-                raise RuntimeError
+                raise RuntimeError from e
         return datas
 
 

--- a/ppgan/models/criterions/builder.py
+++ b/ppgan/models/criterions/builder.py
@@ -38,5 +38,5 @@ def build_criterion(cfg):
         criterion = CRITERIONS.get(name)(**cfg_)
     except Exception as e:
         cls_ = CRITERIONS.get(name)
-        raise RuntimeError('class {} {}'.format(cls_.__name__, e))
+        raise RuntimeError('class {} {}'.format(cls_.__name__, e)) from e
     return criterion

--- a/ppgan/utils/config.py
+++ b/ppgan/utils/config.py
@@ -23,8 +23,8 @@ class AttrDict(dict):
     def __getattr__(self, key):
         try:
             return self[key]
-        except KeyError:
-            raise AttributeError(key)
+        except KeyError as exc:
+            raise AttributeError(key) from exc
 
     def __setattr__(self, key, value):
         if key in self.__dict__:

--- a/ppgan/utils/gfpgan_tools.py
+++ b/ppgan/utils/gfpgan_tools.py
@@ -516,9 +516,8 @@ class MemcachedBackend(BaseStorageBackend):
             sys.path.append(sys_path)
         try:
             import mc
-        except ImportError:
-            raise ImportError(
-                'Please install memcached to enable MemcachedBackend.')
+        except ImportError as exc:
+            raise ImportError('Please install memcached to enable MemcachedBackend.') from exc
         self.server_list_cfg = server_list_cfg
         self.client_cfg = client_cfg
         self._client = mc.MemcachedClient.GetInstance(self.server_list_cfg,
@@ -579,8 +578,8 @@ class LmdbBackend(BaseStorageBackend):
                  **kwargs):
         try:
             import lmdb
-        except ImportError:
-            raise ImportError('Please install lmdb to enable LmdbBackend.')
+        except ImportError as exc:
+            raise ImportError('Please install lmdb to enable LmdbBackend.') from exc
         if isinstance(client_keys, str):
             client_keys = [client_keys]
         if isinstance(db_paths, list):


### PR DESCRIPTION
### Changes Made:

- Applied automated fixes for the pylint warning `raise-missing-from`.
"Python's exception chaining shows the traceback of the current exception, but also of the original exception. When you raise a new exception after another exception was caught it's likely that the second exception is a friendly re-wrapping of the first exception. In such cases `raise from` provides a better link between the two tracebacks in the final error. See [https://pylint.readthedocs.io/en/stable/user_guide/messages/warning/raise-missing-from.html](https://pylint.readthedocs.io/en/stable/user_guide/messages/warning/raise-missing-from.html)"

### Note:

This pull request is part of a research project conducted by researchers from TU Delft, titled "PyWarnFixer: Using ML to Fix Pylint Warnings." The goal of this study is to investigate the perceptions and practices of code quality among developers in Python open-source projects and to develop a tool that uses AI to automatically fix pylint warnings.

### Research Study Information:
This pull request is part of a research project. For more information about the study, please visit the [project's information page](https://github.com/RatishT/PyWarnFixer/blob/main/README.md).

### Consent to Participate:
If you review this pull request, you are invited to participate in our study. Your participation is voluntary. To provide your consent, just open an issue in our repository with the provided template using the following link: [consent issue template](https://github.com/RatishT/PyWarnFixer/issues/new/choose) .

---

Thank you for considering participation in our research. Your feedback is crucial and highly valued. If you have any questions or concerns, please contact the Responsible Researcher at R.K.Thakoersingh@student.tudelft.nl.